### PR TITLE
Fixed reload command and easier update mob eggs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,12 @@
 /target/CreatureCapture-1.11.jar
 /target/CreatureCapture-1.12.jar
 /CreatureCapture.iml
+.idea/saveactions_settings.xml
+.idea/dictionaries
+.idea/misc.xml
+.idea/markdown.xml
+.idea/jarRepositories.xml
+.idea/inspectionProfiles/Project_Default.xml
+.idea/compiler.xml
+.idea/checkstyle-idea.xml
+target/CreatureCapture-2.0.jar

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/src/main/java/me/crylonz/CCCommandExecutor.java
+++ b/src/main/java/me/crylonz/CCCommandExecutor.java
@@ -3,32 +3,55 @@ package me.crylonz;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static me.crylonz.CreatureCapture.generateCaptureBow;
 
-public class CCCommandExecutor implements CommandExecutor {
+public class CCCommandExecutor implements CommandExecutor, TabExecutor {
 
-    private final Plugin plugin;
+	private final Plugin plugin;
 
-    public CCCommandExecutor(Plugin p) {
-        this.plugin = p;
-    }
+	public CCCommandExecutor(Plugin p) {
+		this.plugin = p;
+	}
 
-    @Override
-    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
-        Player player;
-        if ((sender instanceof Player)) {
-            player = (Player) sender;
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+		Player player;
+		if ((sender instanceof Player)) {
+			player = (Player) sender;
 
-            if (cmd.getName().equalsIgnoreCase("cc")) {
-                if (player.hasPermission("creaturecapture.cc")) {
-                    player.getInventory().addItem(generateCaptureBow());
-                }
-            }
-        }
-        return true;
-    }
+			if (cmd.getName().equalsIgnoreCase("cc")) {
+				if (args.length < 1) return true;
+
+				if (args[0].equalsIgnoreCase("get") && (player.hasPermission("creaturecapture.cc") || player.hasPermission("creaturecapture.get"))) {
+					player.getInventory().addItem(generateCaptureBow());
+				}
+
+				if (args[0].equalsIgnoreCase("reload") && player.hasPermission("creaturecapture.reload")) {
+					player.sendMessage("reload config....");
+					plugin.reloadConfig();
+					player.sendMessage("config reloaded.");
+				}
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public List<String> onTabComplete(final CommandSender sender, final Command command, final String label, final String[] args) {
+		List<String> tabs = new ArrayList<>();
+		if (args.length == 1) {
+			if (sender.hasPermission("creaturecapture.cc") || sender.hasPermission("creaturecapture.get"))
+				tabs.add("get");
+			if (sender.hasPermission("creaturecapture.reload"))
+				tabs.add("reload");
+		}
+		return tabs;
+	}
 }

--- a/src/main/java/me/crylonz/CCListener.java
+++ b/src/main/java/me/crylonz/CCListener.java
@@ -1,6 +1,10 @@
 package me.crylonz;
 
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Effect;
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.enchantments.EnchantmentOffer;
 import org.bukkit.entity.Entity;
@@ -22,7 +26,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import static me.crylonz.CreatureCapture.*;
+import static me.crylonz.CreatureCapture.chanceToCapture;
+import static me.crylonz.CreatureCapture.isDisplay;
+import static me.crylonz.CreatureCapture.maxDurability;
+import static me.crylonz.CreatureCapture.players;
+import static me.crylonz.CreatureCapture.randVal;
+import static me.crylonz.CreatureCapture.spawnableMobEggs;
+import static me.crylonz.CreatureCapture.spawnersCanBeModifiedByEgg;
 
 public class CCListener implements Listener {
 
@@ -142,7 +152,8 @@ public class CCListener implements Listener {
                     if (player.hasPermission("creaturecapture.capture")) {
 
                         // if this mob is disable in option
-                        if (!plugin.getConfig().getBoolean(e.getEntity().getType().toString())) {
+                       Boolean allowed = spawnableMobEggs.get(e.getEntity().getType().toString());
+                        if (allowed == null || !allowed) {
                             return;
                         }
 

--- a/src/main/java/me/crylonz/CreatureCapture.java
+++ b/src/main/java/me/crylonz/CreatureCapture.java
@@ -2,6 +2,9 @@ package me.crylonz;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -12,88 +15,163 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
-import java.util.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 public class CreatureCapture extends JavaPlugin implements Listener {
 
-    public static List<Player> players = new ArrayList<>();
-    public static double randVal = 0;
-    public static boolean isDisplay = false;
+	public static List<Player> players = new ArrayList<>();
+	public static double randVal = 0;
+	public static boolean isDisplay = false;
 
-    public final Logger log = Logger.getLogger("Minecraft");
+	public final Logger log = Logger.getLogger("Minecraft");
 
-    // Config File
-    public static int maxDurability = 10;
-    public static double chanceToCapture = 50;
-    public static boolean spawnersCanBeModifiedByEgg = true;
+	// Config File
+	private int dropRate = 3;
+	public static int maxDurability = 10;
+	public static double chanceToCapture = 50;
+	public static boolean spawnersCanBeModifiedByEgg = true;
+	public static Map<String, Boolean> spawnableMobEggs;
 
 
-    public static ItemStack generateCaptureBow() {
-        ItemStack item = new ItemStack(Material.BOW);
-        item.addUnsafeEnchantment(Enchantment.SILK_TOUCH, 1);
-        ItemMeta meta = item.getItemMeta();
-        Objects.requireNonNull(meta).setDisplayName(ChatColor.RED + (ChatColor.BOLD + "Capture Bow") + ChatColor.GOLD);
-        ArrayList<String> lore = new ArrayList<>();
-        lore.add(maxDurability + "/" + maxDurability);
-        meta.setLore(lore);
-        meta.setUnbreakable(true);
-        item.setItemMeta(meta);
-        return item;
-    }
+	public static ItemStack generateCaptureBow() {
+		ItemStack item = new ItemStack(Material.BOW);
+		item.addUnsafeEnchantment(Enchantment.SILK_TOUCH, 1);
+		ItemMeta meta = item.getItemMeta();
+		Objects.requireNonNull(meta).setDisplayName(ChatColor.RED + (ChatColor.BOLD + "Capture Bow") + ChatColor.GOLD);
+		ArrayList<String> lore = new ArrayList<>();
+		lore.add(maxDurability + "/" + maxDurability);
+		meta.setLore(lore);
+		meta.setUnbreakable(true);
+		item.setItemMeta(meta);
+		return item;
+	}
 
-    public void onEnable() {
+	@Override
+	public void onEnable() {
 
-        PluginManager pm = getServer().getPluginManager();
-        pm.registerEvents(new CCListener(this), this);
+		PluginManager pm = getServer().getPluginManager();
+		pm.registerEvents(new CCListener(this), this);
 
-        Objects.requireNonNull(this.getCommand("cc"), "Command dc not found")
-                .setExecutor(new CCCommandExecutor(this));
+		Objects.requireNonNull(this.getCommand("cc"), "Command dc not found").setExecutor(new CCCommandExecutor(this));
 
-        File configFile = new File(this.getDataFolder(), "config.yml");
-        if (!configFile.exists()) {
-            getConfig().options().header("droprate : Chance in percentage to have capture bow appear in enchant table\n" +
-                    "captureBowDurability : Number of arrows that the bow need to break\n" +
-                    "chanceToCapture : Percentage of chance to capture the desired mob with the capture bow\n" +
-                    "spawnersCanBeModifiedByEgg : Enable/Disable right clicking on spawners with egg\n" +
-                    "If you want to disable the ability to capture a specific mob just set false next to mob name\n" +
-                    "PLEASE RELOAD AFTER ANY CHANGE");
-            getConfig().set("droprate", 3.0);
-            getConfig().set("captureBowDurability", maxDurability);
-            getConfig().set("chanceToCapture", chanceToCapture);
-            getConfig().set("spawnersCanBeModifiedByEgg", spawnersCanBeModifiedByEgg);
+		File configFile = new File(this.getDataFolder(), "config.yml");
+		if (!configFile.exists()) {
+			setConfig(getConfig());
+			Map<String, Boolean> mobs = new HashMap<>();
+			for (EntityType e : EntityType.values()) {
+				if (e.isAlive() && e.isSpawnable()) {
+					mobs.put(e.toString(), true);
+				}
+			}
+			getConfig().set("Mob_eggs", mobs);
+			saveConfig();
+		}
 
-            for (EntityType e : EntityType.values()) {
-                if (e.isAlive() && e.isSpawnable()) {
-                    getConfig().set(e.toString(), true);
-                }
-            }
-            saveConfig();
-        }
+		maxDurability = getConfig().getInt("captureBowDurability");
+		chanceToCapture = getConfig().getDouble("chanceToCapture");
+		spawnersCanBeModifiedByEgg = getConfig().getBoolean("spawnersCanBeModifiedByEgg");
+		dropRate = getConfig().getInt("droprate");
+		Map<String, Boolean> mobs = checkOldMobSpawnEggs();
+		convertOldConfig(configFile, dropRate, mobs);
 
-        maxDurability = getConfig().getInt("captureBowDurability");
-        chanceToCapture = getConfig().getDouble("chanceToCapture");
-        spawnersCanBeModifiedByEgg = getConfig().getBoolean("spawnersCanBeModifiedByEgg");
-        randVal = Math.random() * 100;
-    }
+		spawnableMobEggs = loadMobSpawnEggs();
+		Map<String, Boolean> mobsToAdd = checkIfValuesMissing(spawnableMobEggs);
+		if (!mobsToAdd.isEmpty()) {
+			mobsToAdd.forEach((entityName, v) -> getConfig().set("Mob_eggs." + entityName, true));
+			saveConfig();
+			reloadConfig();
+			spawnableMobEggs = loadMobSpawnEggs();
 
-    public void onDisable() {
-    }
+		}
+		randVal = Math.random() * 100;
+	}
 
-    public static class Reminder {
-        Timer timer;
+	@Override
+	public void onDisable() {
+	}
 
-        public Reminder(int seconds) {
-            timer = new Timer();
-            timer.schedule(new RemindTask(), seconds * 1000L);
-        }
+	public static class Reminder {
+		Timer timer;
 
-        class RemindTask extends TimerTask {
-            public void run() {
-                players.clear();
-                timer.cancel();
-            }
-        }
-    }
+		public Reminder(int seconds) {
+			timer = new Timer();
+			timer.schedule(new RemindTask(), seconds * 1000L);
+		}
+
+		class RemindTask extends TimerTask {
+			@Override
+			public void run() {
+				players.clear();
+				timer.cancel();
+			}
+		}
+	}
+
+	private void setConfig(FileConfiguration config) {
+		config.options().header("droprate : Chance in percentage to have capture bow appear in enchant table\n"
+				+ "captureBowDurability : Number of arrows that the bow need to break\n"
+				+ "chanceToCapture : Percentage of chance to capture the desired mob with the capture bow\n"
+				+ "spawnersCanBeModifiedByEgg : Enable/Disable right clicking on spawners with egg\n"
+				+ "If you want to disable the ability to capture a specific mob just set false next to mob name\n"
+				+ "PLEASE RELOAD AFTER ANY CHANGE");
+		config.set("droprate", dropRate);
+		config.set("captureBowDurability", maxDurability);
+		config.set("chanceToCapture", chanceToCapture);
+		config.set("spawnersCanBeModifiedByEgg", spawnersCanBeModifiedByEgg);
+	}
+	private void convertOldConfig(final File configFile, final int dropRate, final Map<String, Boolean> mobs) {
+		if (!mobs.isEmpty()) {
+			YamlConfiguration yamlConfiguration = new YamlConfiguration();
+			setConfig(yamlConfiguration);
+			yamlConfiguration.set("Mob_eggs", mobs);
+			try {
+				yamlConfiguration.save(configFile);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			reloadConfig();
+		}
+	}
+	private Map<String, Boolean> loadMobSpawnEggs() {
+		Map<String, Boolean> spawnableMobEggs = new HashMap<>();
+		ConfigurationSection configurationSection = getConfig().getConfigurationSection("Mob_eggs");
+		if (configurationSection != null)
+			for (String key : configurationSection.getKeys(true)) {
+				spawnableMobEggs.put(key, getConfig().getBoolean("Mob_eggs." +key));
+			}
+		return spawnableMobEggs;
+	}
+
+	private Map<String, Boolean> checkOldMobSpawnEggs() {
+		Map<String, Boolean> mobs = new HashMap<>();
+		for (EntityType e : EntityType.values()) {
+			if (e.isAlive() && e.isSpawnable()) {
+				if (getConfig().contains(e.toString())) {
+					mobs.put(e.toString(), getConfig().getBoolean(e.toString()));
+				}
+			}
+		}
+		return mobs;
+	}
+
+	private Map<String, Boolean> checkIfValuesMissing(final Map<String, Boolean> spawnableMobEggs) {
+		return Arrays.stream(EntityType.values())
+				.filter(entityType -> entityType.isAlive() && entityType.isSpawnable() &&
+						spawnableMobEggs.get(entityType.toString()) == null)
+				.collect(Collectors.toMap(
+						Enum::toString,
+						entityType -> true
+				));
+	}
 }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,9 +6,9 @@ description: Capture monster !
 api-version: "1.13"
 commands:
   cc:
-    description: give you the capture bow
-    usage: /cc
-    permission: creaturecapture.cc
+    description: is the base command for capture bow plugin.
+    usage: /cc <get|reload>
+    #permission: creaturecapture.cc
 
 permissions:
   creaturecapture.capture:
@@ -16,4 +16,10 @@ permissions:
     default: op
   creaturecapture.cc:
     description: Allows you to give you capture bow
+    default: op
+  creaturecapture.get:
+    description: Allows you to give you capture bow
+    default: op
+  creaturecapture.reload:
+    description: Allows you to reload settings.
     default: op


### PR DESCRIPTION
Changelog:
* Fixed so you can reload the config.yml as it stated in the file you can do.
* Change so it convert old eggs to the new format, so you can easy update with new eggs or change old ones.

So this is not small change, but this should make the plugin more future proof and add new mobs when it get added to the game and you don't need to remove the settings file.